### PR TITLE
improved check and warning when the collection does not exist

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -156,21 +156,33 @@ def loadAllProfileInformation():
     global colArray
     for prof in mw.pm.profiles():
         cpath = join(mw.pm.base, prof,  'collection.anki2')
-        try:
-            tempCol = Collection(cpath)
-            noteTypes = tempCol.models.all()
-            tempCol.db.close()
-            tempCol = None
-            noteTypeDict = {}
-            for note in noteTypes:
-                noteTypeDict[note['name']] = {"cardTypes" : [], "fields" : []}
-                for ct in note['tmpls']:
-                    noteTypeDict[note['name']]["cardTypes"].append(ct['name'])
-                for f in note['flds']:
-                    noteTypeDict[note['name']]["fields"].append(f['name'])
-            colArray[prof] = noteTypeDict
-        except:
-            miInfo('<b>Warning:</b><br>Your Anki collection could not be loaded, as a result the MIA Japanese Add-on settings menu will not work correctly. This problem typically occurs when creating a new Anki profile. You can <b>fix this issue by simply restarting Anki after loading your new profile for the first time.<b>', level='wrn')
+        if os.path.isfile(cpath):
+            try:
+                tempCol = Collection(cpath)
+                noteTypes = tempCol.models.all()
+                tempCol.db.close()
+                tempCol = None
+                noteTypeDict = {}
+                for note in noteTypes:
+                    noteTypeDict[note['name']] = {"cardTypes" : [], "fields" : []}
+                    for ct in note['tmpls']:
+                        noteTypeDict[note['name']]["cardTypes"].append(ct['name'])
+                        for f in note['flds']:
+                            noteTypeDict[note['name']]["fields"].append(f['name'])
+                            colArray[prof] = noteTypeDict
+            except:
+                miInfo('Unable to load collection ' + cpath)
+        else:
+                miInfo('''
+<b>Warning:</b>
+<br>Your Anki collection for the profile %s (located at %s) could not be loaded.
+<br>As a result the MIA Japanese Add-on settings menu will not work correctly. 
+<br>This problem typically occurs for two reasons: 
+<ol>
+   <li>You just created a new Anki profile. You can <b>fix this issue by simply restarting Anki after loading your new profile for the first time.</b>
+   <li> The folder of a profile has been deleted. You can <b>fix this issue by deleting the profile in anki</b>
+</ol>
+''' % (prof, cpath), level='wrn')
 
 def openGui():
     if not mw.MIAJSSettings:


### PR DESCRIPTION
When a collection is not found the error message is a bit misleading. I have done two things:

1. Improved handling. The new code first checks if the file exists. If it exists, then only an exception will trigger the generic error "collection cannot be loaded...". Otherwise if the file does not exist a more informative warning is output

2. the warning has been improved: it outputs the name of the profile, the location of the collection file. It also informs the user that there are two reasons for this error: the profile was just created, or the profile's collection cannot be found.