### PR TITLE
reading: add missing copyright header

### DIFF
--- a/src/reading.py
+++ b/src/reading.py
@@ -1,5 +1,14 @@
 # -*- coding: utf-8 -*-
 
+# This file is based on the Japanese Support add-on's reading.py, which can be
+# found at <https://github.com/ankitects/anki-addons>.
+#
+# Copyright: Ankitects Pty Ltd and contributors
+# License: GNU GPL, version 3 or later; http://www.gnu.org/copyleft/gpl.html
+#
+# Automatic reading generation with kakasi and mecab.
+#
+
 import sys, os, platform, re, subprocess, aqt.utils
 from anki.utils import stripHTML, isWin, isMac
 from anki.hooks import addHook


### PR DESCRIPTION
As discussed [here][1], this file was copied from the Anki Japanese Support
add-on with the copyright header removed. This reinstates the original
copyright header and adds a link to where the code originally comes
from.

[1]: https://github.com/migaku-official/Migaku-Japanese-Addon/issues/69#issuecomment-694099443

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>