### PR TITLE
Use reccomened gui_hooks for playAudio JS bridge to avoid affecting other addons

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -12,7 +12,7 @@ from anki.hooks import addHook, wrap, runHook, runFilter
 from aqt.utils import shortcut, saveGeom, saveSplitter, showInfo
 import aqt.editor
 import json
-from aqt import mw
+from aqt import mw, gui_hooks
 from aqt.qt import *
 import copy
 from .miutils import miInfo
@@ -352,27 +352,12 @@ def clickPlayAudio(cmd):
         if exists(path):
             sound.play(path)
 
-def revBridgeReroute(self, cmd):
+def audioBridgeHandler(handled, cmd, context):
     if cmd.startswith('playAudio;'):
         if checkProfile() and getConfig()['PlayAudioOnClick'] == 'on':
             clickPlayAudio(cmd)
-            return
-    else:
-        ogRevReroute(self, cmd)
+        return (True, None)
+    return handled
 
-ogRevReroute = aqt.reviewer.Reviewer._linkHandler 
-aqt.reviewer.Reviewer._linkHandler = revBridgeReroute
-
-def prevBridgeReroute(self, cmd):
-    if cmd.startswith('playAudio;'):
-        if checkProfile() and getConfig()['PlayAudioOnClick'] == 'on':
-            clickPlayAudio(cmd)
-            return
-    else:
-        ogAnkiWebBridge(self, cmd)
-
-
-
-ogAnkiWebBridge = AnkiWebView._onBridgeCmd
-AnkiWebView._onBridgeCmd = prevBridgeReroute
+gui_hooks.webview_did_receive_js_message.append(audioBridgeHandler)
 


### PR DESCRIPTION
Resolves #92 

Hi,

I'm developing an Anki addon and I found how Migaku is "hijacking" the private AnkiWebView _onBridgeCmd prevents a JS callback from being called when handing a  `pycmd` on new webviews. 

The real issue is that prevBridgeReroute in main.py should have a return statement on the last line, like this, so the results can be passed to a JavaScript callback. 

```python
def prevBridgeReroute(self, cmd):
    if cmd.startswith('playAudio;'):
        if checkProfile() and getConfig()['PlayAudioOnClick'] == 'on':
            clickPlayAudio(cmd)
            return
    else:
        return ogAnkiWebBridge(self, cmd)
```

But, the docs recommended using `gui_hooks.webview_did_receive_js_message` here which I think is the cleaner choice. When I make this change, it resolves the issue. Did a test on my Linux machine and the on-click audio still works as expected.
https://addon-docs.ankiweb.net/#/hooks-and-filters?id=webview

webview.py in Anki also discourages setting _onBridgeCmd and onBridgeCmd manually:
```
# in new code, use .set_bridge_command() instead of setting this directly
self.onBridgeCmd: Callable[[str], Any] = self.defaultOnBridgeCmd
```

I'd be happy to make a small addon to show further reproduction steps if needed.