### PR TITLE
Allow empty user overwrites

### DIFF
--- a/src/userExceptionManager.py
+++ b/src/userExceptionManager.py
@@ -245,8 +245,8 @@ class UserExceptionManager:
         self.proxyFilter.setFilterKeyColumn(0)
 
     def addRule(self, original, overwrite, newCards, learnedCards, parentWidget, addMenu = False):
-        if original == '' or overwrite == '':
-            miInfo('The original and overwrite fields should not be empty.', level='not')
+        if original == '':
+            miInfo('The original field should not be empty.', level='not')
             return False, False;
         if original == overwrite:
             miInfo('The original and overwrite fields should not contain the same text.', level='not')


### PR DESCRIPTION
This allows removing furigana and/or pitch accent highlighting one doesn't want, such as for common verbs like する, いる, etc.